### PR TITLE
fix(webdav): decode URI-encoded object paths

### DIFF
--- a/workers/app.ts
+++ b/workers/app.ts
@@ -36,9 +36,21 @@ function getWebdavParams(request: Request): { storageId: string; "*": string } |
   if (!match) {
     return null;
   }
+  const rawPath = match[2] || "";
+  const decodedPath = rawPath
+    .split("/")
+    .map((segment) => {
+      try {
+        return decodeURIComponent(segment);
+      } catch {
+        return segment;
+      }
+    })
+    .join("/");
+
   return {
     storageId: match[1],
-    "*": match[2] || "",
+    "*": decodedPath,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes WebDAV GET and HEAD requests for object keys containing URI-encoded characters.

`URL.pathname` preserves percent-encoded path segments. Passing those segments directly to the S3 client caused `%` to be encoded a second time during request signing, so objects with names containing non-ASCII characters, spaces, `%`, `#`, `?`, `+`, brackets, or emoji could be listed with PROPFIND but returned 404 on GET and HEAD.

This change decodes each path segment once before the S3 client performs its normal encoding and signing. Directory separators are preserved, and malformed percent-encoded segments remain unchanged.

## Validation

- `npm run typecheck`
- `npm run build`
- Verified WebDAV HEAD succeeds for ASCII and Chinese filenames after applying the same fix to a deployed CList instance.
